### PR TITLE
Capture

### DIFF
--- a/modelsQuery.py
+++ b/modelsQuery.py
@@ -72,7 +72,9 @@ def getCaptureStartTime(captureName):
 
 def getCaptureID(captureName):
     capture = models.Capture.query.filter_by(name=captureName).first()
-    return capture.id
+    if capture:
+        return capture.id
+    return None
 
 def getCaptureEndTime(captureName):
     capture = models.Capture.query.filter_by(name=captureName).first()

--- a/static/capture/capture.html
+++ b/static/capture/capture.html
@@ -6,7 +6,9 @@
     <div class="center-block">
       <div class="form-group">
         <label for="captureName">Capture Name</label>
-        <input type="text" class="form-control" id="captureName" maxlength="20" ng-model="captureName">
+        <input type="text" class="form-control" id="captureName" maxlength="20" ng-model="captureName"
+               ng-change="checkCaptureName(captureName)">
+        <div class="warning" ng-if="uniqueName == 'false'">That capture name is already taken!</div>
       </div>
       <div class="form-group">
         <label for="crBucket">Capture Replay Bucket:</label>
@@ -91,8 +93,8 @@
       <button type="button" ng-model="button" ng-click="startCapture()" class="btn-capture btn btn-success"
               ng-disabled="!captureName || !crBucket || !metricsBucket || !rdsInstance || !dbName ||
                            (selectedMode == 'time' && (!startTime || !endTime || !startDate || !endDate ||
-                                                       (startDate == endDate && startTime > endTime))) ||
-                           (selectedMode == 'storage' && !storageNumber)">
+                            (startDate == endDate && startTime > endTime))) ||
+                           (selectedMode == 'storage' && !storageNumber) || uniqueName == 'false'">
       Capture</button>
     </div>
     </div>

--- a/static/capture/capture.js
+++ b/static/capture/capture.js
@@ -179,4 +179,18 @@ app.controller('capture', function ($scope, $location, $http) {
         document.getElementById('mb-button').classList.remove('active');
       }
     }
+
+    $scope.checkCaptureName = function(name) {
+        $http({
+            method: 'GET',
+            url: 'capture/checkName?name=' + name,
+            headers: {
+                'Content-Type' : 'application/json'
+            }
+        }).then(function successCallback(response) {
+            $scope.uniqueName = response.data;
+        }, function errorCallback(response) {
+
+        });
+    };
 });

--- a/static/css/capture.css
+++ b/static/css/capture.css
@@ -21,3 +21,8 @@ h5 {
 .modal-dialog > * {
     color: black;
 }
+
+.warning {
+    color: #ff493a;
+    padding-top: 5px;
+}

--- a/views/capture.py
+++ b/views/capture.py
@@ -59,4 +59,16 @@ def endCapture():
     capture.stopCapture(rdsInstance, database, startTime, endTime, captureName,
                 captureBucket, metricBucket, captureFileName, metricFileName)
 
-    return ""
+    return "ok"
+
+
+@capture_api.route('/checkName', methods=["GET"])
+def checkName():
+    name = request.args.get('name')
+
+    captureId = modelsQuery.getCaptureID(name)
+
+    if captureId is None:
+        return "true"
+    return "false"
+


### PR DESCRIPTION
Start capture is now disabled until the user completes all required fields. If the user attempts to create a capture with a name already existing in the database, a message will pop up stating the capture name already exists and disable the start capture button.

The mode selection UI had to be removed since it conflicted with ng-model and ng-disable.