### PR TITLE
Metrics

### DIFF
--- a/static/capture/capture.html
+++ b/static/capture/capture.html
@@ -142,6 +142,7 @@
 
           <!-- Modal body -->
           <div class="modal-body">
+            <div class="warning" ng-if="instanceDbs == 'false'">RDS Authentication failed.</div>
             <label for="username">Username:</label>
             <input type="text" class="form-control" id="username" ng-model="username" autofocus>
             <label for="password">Password:</label>
@@ -151,7 +152,7 @@
           <!-- Modal footer -->
           <div class="modal-footer">
             <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
-            <button type="button" class="btn btn-primary" data-dismiss="modal"
+            <button type="button" class="btn btn-primary"
             ng-click="getInstanceDbs(rdsInstance)" id="authenticate">Authenticate</button>
           </div>
 

--- a/static/capture/capture.js
+++ b/static/capture/capture.js
@@ -78,8 +78,10 @@ app.controller('capture', function ($scope, $location, $http, buttonDisplay) {
             }).then(function successCallback(response) {
                 console.log(response.data);
                 $scope.instanceDbs = response.data;
+                $('#authenticationModal').modal('hide');
                 console.log('success');
             }, function errorCallback(response) {
+                $scope.instanceDbs = 'false';
                 console.log('error');
             });
         }


### PR DESCRIPTION
Added error warning when the user inputs invalid RDS credentials. The
authentication modal remains open if the authentication fails.